### PR TITLE
Add credentials note and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.ipynb_checkpoints
+downloads/
+*.mp3

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - Google Gemini API キー (`GEMINI_API_KEY`)
 - Google Cloud Text-to-Speech の認証情報
 
+環境変数 `GOOGLE_APPLICATION_CREDENTIALS` はサービスアカウント JSON ファイルへのパスを指定してください。
+
 これらの情報は環境変数として設定してください。
 
 ## セットアップ


### PR DESCRIPTION
## Summary
- document how GOOGLE_APPLICATION_CREDENTIALS should point to a service-account JSON
- keep the last setup step on one line
- add common ignores

## Testing
- `python -m py_compile app.py pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f0f1f65483298557816f472ff9fa