### PR TITLE
Add view and subscriber counts to search results

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,6 +104,10 @@ if st.button("検索") and YT_KEY:
 
     for idx, vid in enumerate(results, 1):
         st.markdown(f"[{vid['title']}]({vid['url']})")
+        if 'viewCount' in vid and 'subscriberCount' in vid:
+            st.write(
+                f"再生回数: {vid['viewCount']:,}  登録者数: {vid['subscriberCount']:,}"
+            )
         if st.button("この動画で生成", key=vid["videoId"]):
             progress = st.progress(0)
             status = st.empty()

--- a/pipeline.py
+++ b/pipeline.py
@@ -80,7 +80,11 @@ def search_videos(
     min_duration: int = 0,
     max_duration: Optional[int] = None,
 ) -> List[dict]:
-    """Search YouTube videos and return list of results filtered by criteria."""
+    """Search YouTube videos and return list of results filtered by criteria.
+
+    Each result dictionary contains ``videoId``, ``title``, ``url``,
+    ``viewCount`` and ``subscriberCount``.
+    """
     youtube = build("youtube", "v3", developerKey=api_key)
 
     search_params: Dict[str, str] = {
@@ -145,7 +149,15 @@ def search_videos(
         if max_duration is not None and duration > max_duration:
             continue
 
-        results.append({"videoId": vid, "title": title, "url": url})
+        results.append(
+            {
+                "videoId": vid,
+                "title": title,
+                "url": url,
+                "viewCount": views,
+                "subscriberCount": subs,
+            }
+        )
         if len(results) >= max_results:
             break
 


### PR DESCRIPTION
## Summary
- include `viewCount` and `subscriberCount` fields when searching videos
- display those counts in the Streamlit results list

## Testing
- `python3 -m py_compile app.py pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684342bfce748329b5146b1e9761ab0a