### PR TITLE
Add advanced search filters to Django view

### DIFF
--- a/summary/tests.py
+++ b/summary/tests.py
@@ -1,7 +1,46 @@
 from django.test import TestCase, Client
+from unittest.mock import patch
+import os
 
 
 class BasicViewTests(TestCase):
     def test_index(self):
         response = Client().get("/")
         self.assertEqual(response.status_code, 200)
+
+    @patch("summary.views.pipeline_proxy.search_videos")
+    def test_search_with_params(self, mock_search):
+        mock_search.return_value = []
+        params = {
+            "search": "",
+            "keyword": "test",
+            "lang": "en",
+            "after": "2024-01-01",
+            "before": "2024-06-30",
+            "min_views": "100",
+            "max_views": "1000",
+            "min_subs": "50",
+            "max_subs": "500",
+            "min_length": "1",
+            "max_length": "2",
+            "length": "short",
+            "max_results": "10",
+        }
+        with patch.dict(os.environ, {"YT_KEY": "dummy"}):
+            response = Client().get("/", params)
+        self.assertEqual(response.status_code, 200)
+        mock_search.assert_called_with(
+            "dummy",
+            "test",
+            "en",
+            max_results=10,
+            video_duration="short",
+            published_after="2024-01-01T00:00:00Z",
+            published_before="2024-06-30T00:00:00Z",
+            min_view_count=100,
+            max_view_count=1000,
+            min_subscribers=50,
+            max_subscribers=500,
+            min_duration=60,
+            max_duration=120,
+        )

--- a/summary/views.py
+++ b/summary/views.py
@@ -8,6 +8,18 @@ def index(request):
     """Search YouTube videos and display results."""
     keyword = request.GET.get("keyword", "")
     video_url = request.GET.get("video_url", "")
+    lang = request.GET.get("lang", "any")
+    after = request.GET.get("after", "")
+    before = request.GET.get("before", "")
+    min_views = request.GET.get("min_views", "")
+    max_views = request.GET.get("max_views", "")
+    min_subs = request.GET.get("min_subs", "")
+    max_subs = request.GET.get("max_subs", "")
+    min_length = request.GET.get("min_length", "")
+    max_length = request.GET.get("max_length", "")
+    length = request.GET.get("length", "any")
+    max_results = request.GET.get("max_results", "5")
+
     results = []
     if "search" in request.GET:
         yt_key = os.environ.get("YT_KEY")
@@ -19,8 +31,37 @@ def index(request):
                     if info:
                         results = [info]
             elif keyword:
-                results = pipeline_proxy.search_videos(yt_key, keyword, "any")
-    context = {"results": results, "keyword": keyword, "video_url": video_url}
+                results = pipeline_proxy.search_videos(
+                    yt_key,
+                    keyword,
+                    lang,
+                    max_results=int(max_results or 5),
+                    video_duration=length,
+                    published_after=f"{after}T00:00:00Z" if after else None,
+                    published_before=f"{before}T00:00:00Z" if before else None,
+                    min_view_count=int(min_views or 0),
+                    max_view_count=int(max_views) if max_views else None,
+                    min_subscribers=int(min_subs or 0),
+                    max_subscribers=int(max_subs) if max_subs else None,
+                    min_duration=int(min_length or 0) * 60,
+                    max_duration=int(max_length) * 60 if max_length else None,
+                )
+    context = {
+        "results": results,
+        "keyword": keyword,
+        "video_url": video_url,
+        "lang": lang,
+        "after": after,
+        "before": before,
+        "min_views": min_views,
+        "max_views": max_views,
+        "min_subs": min_subs,
+        "max_subs": max_subs,
+        "min_length": min_length,
+        "max_length": max_length,
+        "length": length,
+        "max_results": max_results,
+    }
     return render(request, "summary/index.html", context)
 
 

--- a/templates/summary/index.html
+++ b/templates/summary/index.html
@@ -7,7 +7,58 @@
     <h1>YouTube Search</h1>
     <form method="get">
         <input type="text" name="keyword" placeholder="Keyword" value="{{ keyword }}">
-        <input type="text" name="video_url" placeholder="Video URL" value="{{ video_url }}">
+        <input type="text" name="video_url" placeholder="Video URL" value="{{ video_url }}"><br>
+
+        <label>Language:
+            <select name="lang">
+                <option value="any" {% if lang == 'any' %}selected{% endif %}>any</option>
+                <option value="ja" {% if lang == 'ja' %}selected{% endif %}>ja</option>
+                <option value="en" {% if lang == 'en' %}selected{% endif %}>en</option>
+                <option value="es" {% if lang == 'es' %}selected{% endif %}>es</option>
+            </select>
+        </label><br>
+
+        <label>Published After:
+            <input type="date" name="after" value="{{ after }}">
+        </label>
+        <label>Published Before:
+            <input type="date" name="before" value="{{ before }}">
+        </label><br>
+
+        <label>Min Views:
+            <input type="number" name="min_views" value="{{ min_views }}">
+        </label>
+        <label>Max Views:
+            <input type="number" name="max_views" value="{{ max_views }}">
+        </label><br>
+
+        <label>Min Subscribers:
+            <input type="number" name="min_subs" value="{{ min_subs }}">
+        </label>
+        <label>Max Subscribers:
+            <input type="number" name="max_subs" value="{{ max_subs }}">
+        </label><br>
+
+        <label>Min Length (min):
+            <input type="number" name="min_length" value="{{ min_length }}">
+        </label>
+        <label>Max Length (min):
+            <input type="number" name="max_length" value="{{ max_length }}">
+        </label><br>
+
+        <label>Length:
+            <select name="length">
+                <option value="any" {% if length == 'any' %}selected{% endif %}>any</option>
+                <option value="short" {% if length == 'short' %}selected{% endif %}>short</option>
+                <option value="medium" {% if length == 'medium' %}selected{% endif %}>medium</option>
+                <option value="long" {% if length == 'long' %}selected{% endif %}>long</option>
+            </select>
+        </label><br>
+
+        <label>Max Results:
+            <input type="number" name="max_results" value="{{ max_results }}">
+        </label><br>
+
         <button type="submit" name="search">Search</button>
     </form>
     {% if results %}


### PR DESCRIPTION
## Summary
- extend index page with inputs for language, dates, view/subscriber counts, length and result count
- parse those new GET parameters in `views.py`
- keep submitted values in the form
- test that search parameters are passed to the pipeline

## Testing
- `python manage.py test summary`

------
https://chatgpt.com/codex/tasks/task_e_6843fdd93dd48329b2f44f35d86eed5c