### PR TITLE
Add language option for summarization

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -198,11 +198,11 @@ def download_and_transcribe(
     return result["text"]
 
 
-def summarize_with_gemini(api_key: str, text: str) -> str:
-    """Summarize transcript in Japanese using Gemini."""
+def summarize_with_gemini(api_key: str, text: str, *, lang: str = "ja") -> str:
+    """Summarize transcript in the specified language using Gemini."""
     genai.configure(api_key=api_key)
     model = genai.GenerativeModel("gemini-pro")
-    prompt = f"次の内容を日本語でゆっくり解説してください:\n{text}"
+    prompt = f"次の内容を{lang}でゆっくり解説してください:\n{text}"
     response = model.generate_content(prompt)
     return response.text
 

--- a/summary/pipeline_proxy.py
+++ b/summary/pipeline_proxy.py
@@ -23,8 +23,8 @@ def download_and_transcribe(*args, **kwargs):
     return _get_pipeline().download_and_transcribe(*args, **kwargs)
 
 
-def summarize_with_gemini(*args, **kwargs):
-    return _get_pipeline().summarize_with_gemini(*args, **kwargs)
+def summarize_with_gemini(api_key, text, *, lang="ja"):
+    return _get_pipeline().summarize_with_gemini(api_key, text, lang=lang)
 
 
 def synthesize_text_to_mp3(*args, **kwargs):

--- a/summary/test_views.py
+++ b/summary/test_views.py
@@ -1,0 +1,16 @@
+from django.test import TestCase, Client
+from unittest.mock import patch
+import os
+
+
+class ProcessVideoTests(TestCase):
+    @patch("summary.views.pipeline_proxy.summarize_with_gemini")
+    @patch("summary.views.pipeline_proxy.download_and_transcribe")
+    def test_process_video_passes_lang(self, mock_transcribe, mock_summarize):
+        mock_transcribe.return_value = "text"
+        mock_summarize.return_value = "script"
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "key"}):
+            response = Client().get("/process/abc123/?lang=en")
+        self.assertEqual(response.status_code, 200)
+        mock_summarize.assert_called_with("key", "text", lang="en")
+

--- a/summary/views.py
+++ b/summary/views.py
@@ -9,6 +9,7 @@ def index(request):
     keyword = request.GET.get("keyword", "")
     video_url = request.GET.get("video_url", "")
     lang = request.GET.get("lang", "any")
+    script_lang = request.GET.get("script_lang", "ja")
     after = request.GET.get("after", "")
     before = request.GET.get("before", "")
     min_views = request.GET.get("min_views", "")
@@ -51,6 +52,7 @@ def index(request):
         "keyword": keyword,
         "video_url": video_url,
         "lang": lang,
+        "script_lang": script_lang,
         "after": after,
         "before": before,
         "min_views": min_views,
@@ -68,9 +70,10 @@ def index(request):
 def process_video(request, video_id):
     """Run pipeline on selected video."""
     transcript = pipeline_proxy.download_and_transcribe(video_id)
+    script_lang = request.GET.get("lang", "ja")
     gemini_key = os.environ.get("GEMINI_API_KEY")
     script = (
-        pipeline_proxy.summarize_with_gemini(gemini_key, transcript)
+        pipeline_proxy.summarize_with_gemini(gemini_key, transcript, lang=script_lang)
         if gemini_key
         else transcript
     )

--- a/templates/summary/index.html
+++ b/templates/summary/index.html
@@ -17,6 +17,13 @@
                 <option value="es" {% if lang == 'es' %}selected{% endif %}>es</option>
             </select>
         </label><br>
+        <label>Script Language:
+            <select name="script_lang">
+                <option value="ja" {% if script_lang == 'ja' %}selected{% endif %}>ja</option>
+                <option value="en" {% if script_lang == 'en' %}selected{% endif %}>en</option>
+                <option value="es" {% if script_lang == 'es' %}selected{% endif %}>es</option>
+            </select>
+        </label><br>
 
         <label>Published After:
             <input type="date" name="after" value="{{ after }}">
@@ -66,7 +73,7 @@
         {% for vid in results %}
         <li>
             <a href="{{ vid.url }}" target="_blank">{{ vid.title }}</a>
-            [<a href="{% url 'process_video' vid.videoId %}">Process</a>]
+            [<a href="{% url 'process_video' vid.videoId %}?lang={{ script_lang }}">Process</a>]
         </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary
- make `summarize_with_gemini` accept a language option
- forward language param through `pipeline_proxy`
- allow selecting script language on the search page
- send selected language when processing a video
- test that the chosen language is forwarded correctly

## Testing
- `python manage.py test summary`

------
https://chatgpt.com/codex/tasks/task_e_68440095ecb8832999f6b6071d51b1fe