### PR TITLE
Update CI matrix to supported Python versions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- target new python versions for GitHub Actions CI

## Testing
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6844098c321083298614a4808f75ac13