### PR TITLE
Add audio language support

### DIFF
--- a/summary/test_views.py
+++ b/summary/test_views.py
@@ -44,3 +44,14 @@ class BasicViewTests(TestCase):
             min_duration=60,
             max_duration=120,
         )
+
+    @patch("summary.views.pipeline_proxy.synthesize_text_to_mp3")
+    @patch("summary.views.pipeline_proxy.download_and_transcribe")
+    def test_process_video_audio_lang(self, mock_transcribe, mock_synth):
+        mock_transcribe.return_value = "hi"
+        mock_synth.return_value = b"mp3"
+        params = {"lang": "en", "audio": "en-US"}
+        with patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": "1"}):
+            response = Client().get("/process/abc/", params)
+        self.assertEqual(response.status_code, 200)
+        mock_synth.assert_called_with("hi", language_code="en-US")

--- a/summary/views.py
+++ b/summary/views.py
@@ -10,6 +10,7 @@ def index(request):
     video_url = request.GET.get("video_url", "")
     lang = request.GET.get("lang", "any")
     script_lang = request.GET.get("script_lang", "ja")
+    audio_lang = request.GET.get("audio_lang", "ja-JP")
     after = request.GET.get("after", "")
     before = request.GET.get("before", "")
     min_views = request.GET.get("min_views", "")
@@ -53,6 +54,7 @@ def index(request):
         "video_url": video_url,
         "lang": lang,
         "script_lang": script_lang,
+        "audio_lang": audio_lang,
         "after": after,
         "before": before,
         "min_views": min_views,
@@ -71,6 +73,7 @@ def process_video(request, video_id):
     """Run pipeline on selected video."""
     transcript = pipeline_proxy.download_and_transcribe(video_id)
     script_lang = request.GET.get("lang", "ja")
+    audio_lang = request.GET.get("audio", "ja-JP")
     gemini_key = os.environ.get("GEMINI_API_KEY")
     script = (
         pipeline_proxy.summarize_with_gemini(gemini_key, transcript, lang=script_lang)
@@ -84,7 +87,9 @@ def process_video(request, video_id):
     )
     audio_b64 = None
     if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
-        audio = pipeline_proxy.synthesize_text_to_mp3(script)
+        audio = pipeline_proxy.synthesize_text_to_mp3(
+            script, language_code=audio_lang
+        )
         audio_b64 = base64.b64encode(audio).decode("utf-8")
     context = {"video_id": video_id, "script": script, "audio_b64": audio_b64}
     return render(request, "summary/process.html", context)

--- a/templates/summary/index.html
+++ b/templates/summary/index.html
@@ -24,6 +24,13 @@
                 <option value="es" {% if script_lang == 'es' %}selected{% endif %}>es</option>
             </select>
         </label><br>
+        <label>Audio Language:
+            <select name="audio_lang">
+                <option value="ja-JP" {% if audio_lang == 'ja-JP' %}selected{% endif %}>JP</option>
+                <option value="en-US" {% if audio_lang == 'en-US' %}selected{% endif %}>EN</option>
+                <option value="es-ES" {% if audio_lang == 'es-ES' %}selected{% endif %}>ES</option>
+            </select>
+        </label><br>
 
         <label>Published After:
             <input type="date" name="after" value="{{ after }}">
@@ -73,7 +80,7 @@
         {% for vid in results %}
         <li>
             <a href="{{ vid.url }}" target="_blank">{{ vid.title }}</a>
-            [<a href="{% url 'process_video' vid.videoId %}?lang={{ script_lang }}">Process</a>]
+            [<a href="{% url 'process_video' vid.videoId %}?lang={{ script_lang }}&audio={{ audio_lang }}">Process</a>]
         </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary
- add `audio_lang` dropdown in search form
- include audio language in process link
- pass `audio_lang` through views and synthesis
- test that process view forwards audio language to synthesis

## Testing
- `python manage.py test summary`

------
https://chatgpt.com/codex/tasks/task_e_684420e77a5483298534dd015e95d874