### PR TITLE
Ensure downloaded audio cleaned up

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -194,7 +194,13 @@ def download_and_transcribe(
         file_path = ydl.prepare_filename(info)
 
     model = whisper.load_model(whisper_model)
-    result = model.transcribe(file_path)
+    try:
+        result = model.transcribe(file_path)
+    finally:
+        try:
+            os.remove(file_path)
+        except OSError:
+            pass
     return result["text"]
 
 


### PR DESCRIPTION
## Summary
- remove downloaded audio file in `download_and_transcribe`
- verify cleanup of `downloads/` directory

## Testing
- `python manage.py test`
- manual invocation of `download_and_transcribe` with stubbed modules

------
https://chatgpt.com/codex/tasks/task_e_6844391b7b608329a21e3917d1a54451