### PR TITLE
Enable processing multiple videos

### DIFF
--- a/summary/urls.py
+++ b/summary/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('', views.index, name='index'),
     path('process/<str:video_id>/', views.process_video, name='process_video'),
+    path('process-multi/', views.process_multiple, name='process_multiple'),
 ]

--- a/templates/summary/index.html
+++ b/templates/summary/index.html
@@ -76,14 +76,21 @@
         <button type="submit" name="search">Search</button>
     </form>
     {% if results %}
-    <ul>
-        {% for vid in results %}
-        <li>
-            <a href="{{ vid.url }}" target="_blank">{{ vid.title }}</a>
-            [<a href="{% url 'process_video' vid.videoId %}?lang={{ script_lang }}&audio={{ audio_lang }}">Process</a>]
-        </li>
-        {% endfor %}
-    </ul>
+    <form method="post" action="{% url 'process_multiple' %}">
+        {% csrf_token %}
+        <input type="hidden" name="script_lang" value="{{ script_lang }}">
+        <input type="hidden" name="audio_lang" value="{{ audio_lang }}">
+        <ul>
+            {% for vid in results %}
+            <li>
+                <input type="checkbox" name="video_ids" value="{{ vid.videoId }}">
+                <a href="{{ vid.url }}" target="_blank">{{ vid.title }}</a>
+                [<a href="{% url 'process_video' vid.videoId %}?lang={{ script_lang }}&audio={{ audio_lang }}">Process</a>]
+            </li>
+            {% endfor %}
+        </ul>
+        <button type="submit">Process Selected</button>
+    </form>
     {% endif %}
 </body>
 </html>

--- a/templates/summary/multi_process.html
+++ b/templates/summary/multi_process.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Process Multiple Videos</title>
+</head>
+<body>
+    <h1>Processed {{ video_ids|join:", " }}</h1>
+    {% if script %}
+    <h2>Script</h2>
+    <pre>{{ script }}</pre>
+    {% endif %}
+    {% if audio_b64 %}
+    <h2>Audio</h2>
+    <audio controls>
+        <source src="data:audio/mpeg;base64,{{ audio_b64 }}" type="audio/mpeg">
+    </audio>
+    {% endif %}
+    <p><a href="/">Back</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow selecting multiple search results
- add `process_multiple` view and template
- register `process-multi/` route
- test new flow

## Testing
- `python -m pip install django==5.2.2`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68443cdbcf00832998b7e26b5e6620e2