### PR TITLE
Fix script generation error handling

### DIFF
--- a/summary/views.py
+++ b/summary/views.py
@@ -104,11 +104,13 @@ def process_video(request, video_id):
             )
         except Exception as e:
             errors.append(str(e))
-    script = (
-        pipeline_proxy.generate_discussion_script(gemini_key, script, lang=script_lang)
-        if gemini_key
-        else script
-    )
+    if gemini_key and script:
+        try:
+            script = pipeline_proxy.generate_discussion_script(
+                gemini_key, script, lang=script_lang
+            )
+        except Exception as e:
+            errors.append(str(e))
 
     audio_b64 = None
     if credentials and script:
@@ -159,11 +161,13 @@ def process_multiple(request):
             )
         except Exception as e:
             errors.append(str(e))
-    script = (
-        pipeline_proxy.generate_discussion_script(gemini_key, script, lang=script_lang)
-        if gemini_key
-        else script
-    )
+    if gemini_key and script:
+        try:
+            script = pipeline_proxy.generate_discussion_script(
+                gemini_key, script, lang=script_lang
+            )
+        except Exception as e:
+            errors.append(str(e))
 
     audio_b64 = None
     if credentials and script:


### PR DESCRIPTION
## Summary
- handle errors when generating discussion scripts

## Testing
- `python -m py_compile summary/views.py`
- `pip install -r requirements.txt` *(fails: Django not found)*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684544c552ac8329b6a5ded974f2ce11