### PR TITLE
Add optional yt-dlp cookies support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ GEMINI_API_KEY=
 # Optional: Gemini model path (default: models/gemini-pro)
 GEMINI_MODEL=models/gemini-pro
 GOOGLE_APPLICATION_CREDENTIALS=
+YTDLP_COOKIES=

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ YT_KEY=ここを上書きしてください
 GEMINI_API_KEY=ここを上書きしてください
 GEMINI_MODEL=models/gemini-pro
 GOOGLE_APPLICATION_CREDENTIALS=ここを上書きしてください
+YTDLP_COOKIES=
 ```
+
+`YTDLP_COOKIES` には、年齢制限やログインが必要な動画を処理するときに使用する
+cookie ファイルへのパスを指定します。
 
 ## セットアップ
 1. 依存パッケージをインストールします。

--- a/pipeline.py
+++ b/pipeline.py
@@ -189,6 +189,11 @@ def download_and_transcribe(
         "outtmpl": os.path.join(out_dir, f"{video_id}.%(ext)s"),
         "format": "bestaudio/best",
     }
+
+    # Use cookies for age-restricted or authenticated videos
+    cookies_path = os.getenv("YTDLP_COOKIES")
+    if cookies_path and os.path.exists(cookies_path):
+        ydl_opts["cookiefile"] = cookies_path
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         info = ydl.extract_info(f"https://youtu.be/{video_id}", download=True)
         file_path = ydl.prepare_filename(info)


### PR DESCRIPTION
## Summary
- allow using cookies in `download_and_transcribe`
- document optional cookie path in `.env.example`
- explain `YTDLP_COOKIES` in README environment setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68457e71ee4083298b64ac1564cedb23