### PR TITLE
Document gunicorn timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,5 @@ GOOGLE_APPLICATION_CREDENTIALS=
 # Optional: cookie file for age-restricted videos
 YTDLP_COOKIES=
 WHISPER_MODEL=base
+# Optional: Gunicorn timeout in seconds (default: 120)
+GUNICORN_TIMEOUT=120

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn slower_site.wsgi
+web: gunicorn slower_site.wsgi --timeout ${GUNICORN_TIMEOUT:-120}

--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ GEMINI_MODEL=models/gemini-pro
 GOOGLE_APPLICATION_CREDENTIALS=ここを上書きしてください
 YTDLP_COOKIES=
 WHISPER_MODEL=base
+GUNICORN_TIMEOUT=120
 ```
 
 `YTDLP_COOKIES` には、年齢制限やログインが必要な動画を処理するときに使用する cookie ファイルへのパスを指定します。
 `WHISPER_MODEL` を指定すると Whisper のモデルサイズを変更できます。デフォルトは `base` ですが、`tiny` などの小さいモデルを使うとメモリ使用量を抑えられ、Gunicorn のタイムアウトを避けられる場合があります。
+`GUNICORN_TIMEOUT` で Gunicorn のタイムアウト秒数を調整できます。Whisper モデルを低スペックのハードウェアで使用する際は、処理に時間がかかるためより長いタイムアウトが必要になることがあります。
 
 ## セットアップ
 1. 依存パッケージをインストールします。


### PR DESCRIPTION
## Summary
- set gunicorn timeout via `GUNICORN_TIMEOUT` in Procfile
- add `GUNICORN_TIMEOUT` environment variable example
- explain when longer timeouts help with Whisper

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68458583be388329a4f52d23efa7abf5