### PR TITLE
Update pipeline cookie loading

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -13,8 +13,6 @@ import whisper
 import google.generativeai as genai
 
 
-# Path to a cookies file for yt-dlp (optional)
-YTDLP_COOKIES = os.getenv("YTDLP_COOKIES")
 
 
 def _iso_duration_to_seconds(duration: str) -> int:
@@ -197,8 +195,9 @@ def download_and_transcribe(video_id: str, *, out_dir: str = "downloads") -> str
     }
 
     # Use cookies for age-restricted or authenticated videos
-    if YTDLP_COOKIES and os.path.exists(YTDLP_COOKIES):
-        ydl_opts["cookiefile"] = YTDLP_COOKIES
+    cookies_path = os.getenv("YTDLP_COOKIES")
+    if cookies_path and os.path.exists(cookies_path):
+        ydl_opts["cookiefile"] = cookies_path
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         info = ydl.extract_info(f"https://youtu.be/{video_id}", download=True)
         file_path = ydl.prepare_filename(info)


### PR DESCRIPTION
## Summary
- load `YTDLP_COOKIES` inside `download_and_transcribe`
- ensure `cookiefile` option is added only if the path exists

## Testing
- `python -m py_compile pipeline.py slower_site/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6845865c27748329848638c2fc62a0f5