### PR TITLE
Update env var usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@
   - 省略可。別のモデルを使う場合はこの値を変更してください
 - Google Cloud Text-to-Speech の認証情報
 - yt-dlp で利用する cookie ファイル (`YTDLP_COOKIES`, 任意)
+  - 年齢制限付き動画をダウンロードする際に使用
 - Whisper のモデル名 (`WHISPER_MODEL`, デフォルト `base`)
+  - 文字起こしに使う Whisper モデルを指定
 - Gunicorn のタイムアウト秒数 (`GUNICORN_TIMEOUT`, デフォルト `120`)
+  - デプロイ時の処理時間に合わせて調整
 
 環境変数 `GOOGLE_APPLICATION_CREDENTIALS` はサービスアカウント JSON ファイルへのパスを指定してください。
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -189,21 +189,21 @@ def download_and_transcribe(video_id: str, *, out_dir: str = "downloads") -> str
     (default ``"base"``).
     """
     os.makedirs(out_dir, exist_ok=True)
+    model_name = os.getenv("WHISPER_MODEL", "base")
+    cookies = os.getenv("YTDLP_COOKIES")
     ydl_opts = {
         "outtmpl": os.path.join(out_dir, f"{video_id}.%(ext)s"),
         "format": "bestaudio/best",
     }
 
     # Use cookies for age-restricted or authenticated videos
-    cookies_path = os.getenv("YTDLP_COOKIES")
-    if cookies_path and os.path.exists(cookies_path):
-        ydl_opts["cookiefile"] = cookies_path
+    if cookies and os.path.exists(cookies):
+        ydl_opts["cookiefile"] = cookies
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         info = ydl.extract_info(f"https://youtu.be/{video_id}", download=True)
         file_path = ydl.prepare_filename(info)
 
-    whisper_model = os.getenv("WHISPER_MODEL", "base")
-    model = whisper.load_model(whisper_model)
+    model = whisper.load_model(model_name)
     try:
         result = model.transcribe(file_path)
     finally:


### PR DESCRIPTION
## Summary
- load Whisper model with env vars before downloading
- describe YTDLP_COOKIES, WHISPER_MODEL and GUNICORN_TIMEOUT in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845adb6af208329835558fcb05116dc