### PR TITLE
Implement step-by-step video processing

### DIFF
--- a/summary/urls.py
+++ b/summary/urls.py
@@ -5,4 +5,10 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('process/<str:video_id>/', views.process_video, name='process_video'),
     path('process-multi/', views.process_multiple, name='process_multiple'),
+    path('step/<str:video_id>/', views.show_process, name='show_process'),
+    path('step/<str:video_id>/transcribe/', views.transcribe_step, name='transcribe_step'),
+    path('step/<str:video_id>/summarize/', views.summarize_step, name='summarize_step'),
+    path('step/<str:video_id>/script/', views.generate_script_step, name='generate_script_step'),
+    path('step/<str:video_id>/synthesize/', views.synthesize_step, name='synthesize_step'),
+    path('step/<str:video_id>/clear/', views.clear_process, name='clear_process'),
 ]

--- a/templates/summary/index.html
+++ b/templates/summary/index.html
@@ -91,7 +91,7 @@
             <li>
                 <input type="checkbox" name="video_ids" value="{{ vid.videoId }}">
                 <a href="{{ vid.url }}" target="_blank">{{ vid.title }}</a>
-                [<a href="{% url 'process_video' vid.videoId %}?lang={{ script_lang }}&audio={{ audio_lang }}">Process</a>]
+                [<a href="{% url 'show_process' vid.videoId %}?lang={{ script_lang }}&audio={{ audio_lang }}">Process</a>]
             </li>
             {% endfor %}
         </ul>

--- a/templates/summary/process.html
+++ b/templates/summary/process.html
@@ -11,16 +11,28 @@
     {% if steps %}
     <pre>{{ steps }}</pre>
     {% endif %}
+
+    <p>
+        <a href="{% url 'transcribe_step' video_id %}">文字起こし実行</a> |
+        <a href="{% url 'summarize_step' video_id %}">要約実行</a> |
+        <a href="{% url 'generate_script_step' video_id %}">台本生成</a> |
+        <a href="{% url 'synthesize_step' video_id %}">MP3生成</a> |
+        <a href="{% url 'clear_process' video_id %}">クリア</a>
+    </p>
+
     {% if script %}
     <h2>Script</h2>
     <pre>{{ script }}</pre>
     {% endif %}
+
     {% if audio_b64 %}
     <h2>Audio</h2>
     <audio controls>
         <source src="data:audio/mpeg;base64,{{ audio_b64 }}" type="audio/mpeg">
     </audio>
+    <p><a href="data:audio/mpeg;base64,{{ audio_b64 }}" download="{{ video_id }}.mp3">ダウンロード</a></p>
     {% endif %}
+
     <p><a href="/">Back</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add redirect import
- introduce step-by-step endpoints for transcription, summarization, script creation, and audio synthesis
- expose new routes for the steps
- allow launching step process from results page
- show buttons on process page to run each step and download MP3
- fix small typo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845afa236588329911c3d3c6aec51cf