### PR TITLE
Add usage notes for Whisper model and Gunicorn timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ GEMINI_MODEL=models/gemini-pro
 GOOGLE_APPLICATION_CREDENTIALS=
 # Optional: cookie file for age-restricted videos
 YTDLP_COOKIES=
+# base can be slow on CPUs; tiny or small are faster alternatives
 WHISPER_MODEL=base
-# Optional: Gunicorn timeout in seconds (default: 120)
+# Optional: Gunicorn timeout in seconds (default: 120). Longer timeout may be required when using Whisper on slow hardware
 GUNICORN_TIMEOUT=120


### PR DESCRIPTION
## Summary
- document slower performance of the `base` Whisper model in `.env.example`
- mention that slow hardware may require a longer Gunicorn timeout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465bb721208329ad503ec2ffb0ab83