### PR TITLE
Add WHISPER_BACKEND entry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,7 @@ GOOGLE_APPLICATION_CREDENTIALS=
 YTDLP_COOKIES=
 # base can be slow on CPUs; tiny or small are faster alternatives
 WHISPER_MODEL=base
+# "faster" uses the faster-whisper backend
+WHISPER_BACKEND=openai
 # Optional: Gunicorn timeout in seconds (default: 120). Longer timeout may be required when using Whisper on slow hardware
 GUNICORN_TIMEOUT=120


### PR DESCRIPTION
## Summary
- add `WHISPER_BACKEND` to `.env.example`
- note that the `faster` option uses the `faster-whisper` backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684665f5c21c8329913a7e94887f4971