### PR TITLE
Add PORT configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,5 @@ WHISPER_BACKEND=openai
 WHISPER_COMPUTE_TYPE=int8
 # Optional: Gunicorn timeout in seconds (default: 120). Longer timeout may be required when using Whisper on slow hardware
 GUNICORN_TIMEOUT=120
+# Optional: port for Gunicorn (default: 8000)
+PORT=8000

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn slower_site.wsgi --timeout ${GUNICORN_TIMEOUT:-120}
+web: gunicorn slower_site.wsgi --bind 0.0.0.0:${PORT:-8000} --timeout ${GUNICORN_TIMEOUT:-120}

--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ WHISPER_MODEL=tiny
 WHISPER_BACKEND=openai      # use 'faster' for faster-whisper
 WHISPER_COMPUTE_TYPE=int8   # compute type for faster-whisper
 GUNICORN_TIMEOUT=120
+PORT=8000
 ```
 
 `YTDLP_COOKIES` には、年齢制限やログインが必要な動画を処理するときに使用する cookie ファイルへのパスを指定します。
 `WHISPER_MODEL` を指定すると Whisper のモデルサイズを変更できます。デフォルトは `tiny` です。より大きなモデルを使うと精度は上がりますが、処理時間も長くなります。
 `WHISPER_BACKEND` で文字起こしバックエンドを選択できます。`WHISPER_COMPUTE_TYPE` は faster-whisper の精度を決める値で、CPU では `int8` のままにしてください。
 `GUNICORN_TIMEOUT` で Gunicorn のタイムアウト秒数を調整できます。Whisper モデルを低スペックのハードウェアで使用する際は、処理に時間がかかるためより長いタイムアウトが必要になることがあります。
+`PORT` は Gunicorn が待ち受けるポート番号です。Railway などの PaaS を利用する場合、サービス側から渡される値で上書きしてください。
 ## Performance Tips
 
 CPU 環境でもデフォルトの Whisper モデル `tiny` なら比較的速く処理できます。


### PR DESCRIPTION
## Summary
- bind Gunicorn port in `Procfile`
- provide default `PORT=8000` in `.env.example`
- document `PORT` variable in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684697efdccc8329976a53589a675e15