### PR TITLE
Add nixpacks config for ffmpeg

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,2 @@
+[phases.setup]
+aptPkgs = ["ffmpeg"]


### PR DESCRIPTION
## Summary
- configure Railway build to install ffmpeg via `nixpacks.toml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846a020638083298c622085bc867b1c