### PR TITLE
Implement stock analysis helpers

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -1,0 +1,39 @@
+import pandas as pd
+import yfinance as yf
+from pandas.io.formats.style import Styler
+
+
+def analyze_stock_candlestick(df: pd.DataFrame) -> str:
+    """Return HTML table for candlestick analysis with integer values."""
+    df_int = df.applymap(lambda x: round(x) if isinstance(x, (int, float)) else x)
+    return df_int.to_html(index=False)
+
+
+def predict_future_moves(df: pd.DataFrame) -> str:
+    """Return styled HTML highlighting the '上昇確率' column."""
+    styler: Styler = df.style
+    if "上昇確率" in df.columns:
+        try:
+            import matplotlib  # noqa: F401
+        except Exception:
+            pass
+        else:
+            styler = styler.background_gradient(
+                cmap="RdYlGn",
+                subset=["上昇確率"],
+                vmin=0.5,
+                vmax=1.0,
+            )
+    return styler.to_html()
+
+
+def _load_fundamentals(ticker_symbol: str) -> dict:
+    """Load fundamentals using yfinance with fallbacks."""
+    ticker = yf.Ticker(ticker_symbol)
+    info = getattr(ticker, "info", {}) or {}
+    trailing_pe = info.get("trailingPE")
+    price_to_book = info.get("priceToBook")
+    return {
+        "trailingPE": trailing_pe if trailing_pe is not None else "N/A",
+        "priceToBook": price_to_book if price_to_book is not None else "N/A",
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ Django>=5.2.2
 gunicorn
 psycopg2-binary
 pytest
+
+pandas
+yfinance

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,50 @@
+import sys
+import os
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if root not in sys.path:
+    sys.path.insert(0, root)
+
+import types
+import pandas as pd
+import core.analysis as analysis
+
+
+def test_analyze_stock_candlestick_no_index():
+    df = pd.DataFrame({"open": [1.1, 2.2], "close": [3.3, 4.4]}, index=pd.date_range("2020-01-01", periods=2))
+    html = analysis.analyze_stock_candlestick(df)
+    assert "2020-01-01" not in html
+    assert ">1<" in html and ">3<" in html
+
+
+def test_predict_future_moves_gradient():
+    df = pd.DataFrame({"銘柄": ["AAA"], "上昇確率": [0.75]})
+    html = analysis.predict_future_moves(df)
+    assert "background-color" in html
+
+
+def test_load_fundamentals(monkeypatch):
+    class DummyTicker:
+        def __init__(self, info):
+            self.info = info
+
+    def dummy(symbol):
+        return DummyTicker({"trailingPE": 10, "priceToBook": 1.2})
+
+    monkeypatch.setattr(analysis.yf, "Ticker", dummy)
+    data = analysis._load_fundamentals("AAA")
+    assert data["trailingPE"] == 10
+    assert data["priceToBook"] == 1.2
+
+
+def test_load_fundamentals_missing(monkeypatch):
+    class DummyTicker:
+        def __init__(self, info):
+            self.info = info
+
+    def dummy(symbol):
+        return DummyTicker({})
+
+    monkeypatch.setattr(analysis.yf, "Ticker", dummy)
+    data = analysis._load_fundamentals("AAA")
+    assert data["trailingPE"] == "N/A"
+    assert data["priceToBook"] == "N/A"


### PR DESCRIPTION
## Summary
- add new core analysis module with candlestick and prediction utilities
- style stock probability column using gradient
- load fundamentals from yfinance with fallbacks
- include pandas and yfinance dependencies
- test new analysis helpers

## Testing
- `pip install -q matplotlib`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852ea04b0f483299ab398fb76a56845